### PR TITLE
Build macOS arm wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,7 +54,6 @@ jobs:
             echo "CIBW_ARCHS_MACOS=x86_64" >> $GITHUB_ENV
           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
             echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
-            echo "CIBW_SKIP=pp* cp36-* cp37-* cp38-* cp313-* cp*-musllinux*" >> $GITHUB_ENV
           fi
 
       - uses: pypa/cibuildwheel@v2.22.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,10 +47,17 @@ jobs:
         if: contains(matrix.os, 'macos')
         run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall --build-from-source --formula ./libomp.rb
 
+      - name: Set environment variables for macOS builds
+        if: contains(matrix.os, 'macos')
+        run: |
+          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+            echo "CIBW_ARCHS_MACOS=x86_64" >> $GITHUB_ENV
+          elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
+            echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
+            echo "CIBW_SKIP=cp38-*" >> $GITHUB_ENV
+          fi
+
       - uses: pypa/cibuildwheel@v2.22.0
-        env:
-          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-13' && 'x86_64' || matrix.os == 'macos-14' && 'arm64' || '' }}
-          CIBW_SKIP: ${{ matrix.os == 'macos-14' && 'cp38-*'|| '' }}
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -38,16 +38,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4
 
       - name: Install OpenMP on macOS
-        if: matrix.os == 'macos-13'
+        if: contains(matrix.os, 'macos')
         run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall --build-from-source --formula ./libomp.rb
 
       - uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_ARCHS_MACOS: ${{ matrix.os == 'macos-13' && 'x86_64' || matrix.os == 'macos-14' && 'arm64' || '' }}
+          CIBW_SKIP: ${{ matrix.os == 'macos-14' && 'cp38-*'|| '' }}
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,7 +54,7 @@ jobs:
             echo "CIBW_ARCHS_MACOS=x86_64" >> $GITHUB_ENV
           elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
             echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
-            echo "CIBW_SKIP=cp38-*" >> $GITHUB_ENV
+            echo "CIBW_SKIP=pp* cp36-* cp37-* cp38-* cp313-* cp*-musllinux*" >> $GITHUB_ENV
           fi
 
       - uses: pypa/cibuildwheel@v2.22.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ line_length = 120
 testpaths = ["tests"]
 
 [tool.cibuildwheel]
-skip = "pp* cp36-* cp37-* cp313-* cp*-musllinux*"
+skip = "pp* cp36-* cp37-* cp313-* cp*-musllinux* cp38-macosx_arm64"
 test-command = "pytest {project}/tests"
 test-extras = ["test"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ test-extras = ["test"]
 archs = ["x86_64"]
 
 [tool.cibuildwheel.macos]
-archs = ["x86_64"]
+archs = ["x86_64", "arm64"]
 
 [tool.cibuildwheel.windows]
 archs = ["ARM64", "AMD64", "x86"]


### PR DESCRIPTION
Refs https://github.com/sillsdev/thot/issues/2

- Adds macos-14 runner, which supports Apple Silicon and [Python >=3.9](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#python)
- Tweaks `cibuildwheel` step to build `x86_64` on `macos-13` and `arm64` on `macos-14`

I've verified that wheels are being built on my fork; artifacts are available here:

https://github.com/jacobwegner/thot/actions/runs/12169525364/artifacts/2276331241

I was also able to install the wheels into two projects without issue.