### PR TITLE
Python 3.14 support

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -9,26 +9,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-13, macos-14]
+        os: [ubuntu-22.04, macos-15-intel, macos-15]
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             lib-ext: so
             artifact: linux-x64
-          - os: macos-13
+          - os: macos-15-intel
             lib-ext: dylib
             artifact: osx-x64
-          - os: macos-14
+          - os: macos-15
             lib-ext: dylib
             artifact: osx-arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: lukka/get-cmake@latest
 
       - name: Install OpenMP on macOS
         if: contains(matrix.os, 'macos')
-        run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall --build-from-source --formula ./libomp.rb
+        run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 HOMEBREW_DEVELOPER=1 brew reinstall --build-from-source --formula ./libomp.rb
 
       - name: CMake build
         run: |
@@ -39,7 +39,7 @@ jobs:
         run: ./build/tests/thot_test
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.artifact }}
           path: build/src/shared_library/libthot.${{ matrix.lib-ext }}
@@ -63,7 +63,7 @@ jobs:
             test: "OFF"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: lukka/get-cmake@latest
 
@@ -77,7 +77,7 @@ jobs:
         run: ./build/${{ matrix.arch }}/tests/Release/thot_test
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: win-${{ matrix.arch }}
           path: build/${{ matrix.arch }}/src/shared_library/Release/thot.dll
@@ -88,14 +88,14 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: nuget/setup-nuget@v2
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
           nuget-version: latest
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           path: artifacts
 
@@ -103,7 +103,7 @@ jobs:
         run: nuget pack nuget\Thot.nuspec -Properties Configuration=Release -BasePath nuget -OutputDirectory artifacts
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nuget-package
           path: artifacts/*.nupkg

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build SDist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: true
 
@@ -27,7 +27,7 @@ jobs:
       - name: Check metadata
         run: pipx run twine check dist/*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: cibw-sdist
           path: dist/*.tar.gz
@@ -38,21 +38,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-15-intel, macos-15]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install OpenMP on macOS
         if: contains(matrix.os, 'macos')
-        run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 brew reinstall --build-from-source --formula ./libomp.rb
+        run: HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1 HOMEBREW_DEVELOPER=1 brew reinstall --build-from-source --formula ./libomp.rb
 
       - name: Set environment variables for macOS builds
         if: contains(matrix.os, 'macos')
         run: |
-          if [[ "${{ matrix.os }}" == "macos-13" ]]; then
+          if [[ "${{ matrix.os }}" == "macos-15-intel" ]]; then
             echo "CIBW_ARCHS_MACOS=x86_64" >> $GITHUB_ENV
-          elif [[ "${{ matrix.os }}" == "macos-14" ]]; then
+          elif [[ "${{ matrix.os }}" == "macos-15" ]]; then
             echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
           fi
 
@@ -63,7 +63,7 @@ jobs:
         shell: bash
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: wheelhouse/*.whl
@@ -76,11 +76,11 @@ jobs:
     # if: github.event_name == 'release' && github.event.action == 'published'
 
     steps:
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v6
         with:
           pattern: cibw-*
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ dist/
 __pycache__/
 .venv/
 wheelhouse/
+
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,10 @@ FetchContent_Declare(
 
 set(YAML_CPP_BUILD_TESTS OFF)
 set(YAML_CPP_BUILD_TOOLS OFF)
+
+# Workaround: allow configuring external projects (yaml-cpp) that use old cmake_minimum_required
+set(CMAKE_POLICY_VERSION_MINIMUM 3.5 CACHE STRING "Allow configuring projects requiring older CMake" FORCE)
+
 FetchContent_MakeAvailable(yaml-cpp)
 if(UNIX)
     target_compile_options(yaml-cpp PRIVATE -Wno-effc++)
@@ -100,7 +104,7 @@ if(BUILD_PYTHON_MODULE)
     endif()
     FetchContent_Declare(
       pybind11
-      URL https://github.com/pybind/pybind11/archive/refs/tags/v2.13.6.zip
+      URL https://github.com/pybind/pybind11/archive/refs/tags/v3.0.1.zip
     )
     FetchContent_MakeAvailable(pybind11)
 endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 120
-target-version = ['py38']
+target-version = ['py310']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -44,6 +44,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "ninja",
-    "cmake>=3.12",
+    "cmake>=3.15",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -158,11 +158,11 @@ setup(
     classifiers=[
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Scientific/Engineering :: Mathematics",
@@ -176,7 +176,7 @@ setup(
     cmdclass={"build_ext": CMakeBuild},
     zip_safe=False,
     extras_require={"test": ["pytest", "numpy"]},
-    python_requires=">=3.8, <4.0",
+    python_requires=">=3.10, <4.0",
     packages=["thot"],
     package_data={"thot": ["py.typed", "**/*.pyi"]},
 )

--- a/src/nlp_common/Trie.h
+++ b/src/nlp_common/Trie.h
@@ -279,7 +279,7 @@ template <class KEY, class DATA_TYPE>
 bool Trie<KEY, DATA_TYPE>::erase(const std::vector<KEY>& keySeq)
 {
   unsigned int i;
-  Trie<KEY, DATA_TYPE>*t, tprev;
+  Trie<KEY, DATA_TYPE>*t, *tprev;
   KEY k;
 
   t = this;

--- a/src/python_module/CMakeLists.txt
+++ b/src/python_module/CMakeLists.txt
@@ -53,7 +53,9 @@ if(APPLE)
         TARGET thot_module POST_BUILD
         COMMAND install_name_tool -add_rpath /opt/local/lib/libomp $<TARGET_FILE:thot_module>
         COMMAND install_name_tool -add_rpath /usr/local/opt/libomp/lib $<TARGET_FILE:thot_module>
+        COMMAND install_name_tool -add_rpath /opt/homebrew/opt/libomp/lib $<TARGET_FILE:thot_module>
         COMMAND install_name_tool -change /usr/local/opt/libomp/lib/libomp.dylib @rpath/libomp.dylib $<TARGET_FILE:thot_module>
+        COMMAND install_name_tool -change /opt/homebrew/opt/libomp/lib/libomp.dylib @rpath/libomp.dylib $<TARGET_FILE:thot_module>
         VERBATIM
     )
 endif()

--- a/src/shared_library/CMakeLists.txt
+++ b/src/shared_library/CMakeLists.txt
@@ -11,7 +11,9 @@ if(APPLE)
         TARGET thot POST_BUILD
         COMMAND install_name_tool -add_rpath /opt/local/lib/libomp $<TARGET_FILE:thot>
         COMMAND install_name_tool -add_rpath /usr/local/opt/libomp/lib $<TARGET_FILE:thot>
+        COMMAND install_name_tool -add_rpath /opt/homebrew/opt/libomp/lib $<TARGET_FILE:thot>
         COMMAND install_name_tool -change /usr/local/opt/libomp/lib/libomp.dylib @rpath/libomp.dylib $<TARGET_FILE:thot>
+        COMMAND install_name_tool -change /opt/homebrew/opt/libomp/lib/libomp.dylib @rpath/libomp.dylib $<TARGET_FILE:thot>
         VERBATIM
     )
 endif()


### PR DESCRIPTION
Required for: https://github.com/sillsdev/machine.py/issues/243

This PR:

 - Updates to pybind11 3.0.1 which:
   - Adds support for Python 3.13 and 3.14
   - Removes support for Python 3.8 and 3.9
   - Requires CMake 3.15 or higher
 - Updates the Linux runner from Ubuntu 20.04 to 22.04 (20.04 is no longer supported)
 - Adds support for recent versions of homebrew
 - Updates the GitHub actions to the same versions that machine.py uses
 - Updates the macOS runners to macOS 15 (macOS 13 is no longer supported, and there is no macOS 14 intel runner)
 - Updates openmp on macOS to 21.1.7 (required for clang 17 and macOS 15-26) with the following modifications:
   - Add: `args << "-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9"`
     - This was retained from the previous openmp 14.0.6 formula as the only noted variation from the published homebrew formula.
   - Remove: `keg_only "it can override GCC headers and result in broken builds"`
     - This line was required for gcc, but breaks the clang config used by the runner.
 - Fixes a mistake in the `Trie` template that causes an error in clang 17 (used by macOS 15-26)