### PR TITLE
Update version to 3.4.9, fix build error with G++ 13

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -56,7 +56,7 @@ jobs:
             echo "CIBW_ARCHS_MACOS=arm64" >> $GITHUB_ENV
           fi
 
-      - uses: pypa/cibuildwheel@v2.22.0
+      - uses: pypa/cibuildwheel@v3.3.1
 
       - name: Verify clean directory
         run: git diff --exit-code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 # endif()
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 # set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-project(Thot VERSION 3.4.8 LANGUAGES CXX C)
+project(Thot VERSION 3.4.9 LANGUAGES CXX C)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 

--- a/nuget/Thot.nuspec
+++ b/nuget/Thot.nuspec
@@ -2,7 +2,7 @@
 <package>
 	<metadata>
 		<id>Thot</id>
-		<version>3.4.8</version>
+		<version>3.4.9</version>
 		<title>Thot</title>
 		<authors>Daniel Ortiz-Martínez,SIL International</authors>
 		<owners>sil-lsdev</owners>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ line_length = 120
 testpaths = ["tests"]
 
 [tool.cibuildwheel]
-skip = "cp*-musllinux*"
+skip = "cp314t-* cp*-musllinux*"
 test-command = "pytest {project}/tests"
 test-extras = ["test"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ line_length = 120
 testpaths = ["tests"]
 
 [tool.cibuildwheel]
-skip = "pp* cp36-* cp37-* cp313-* cp*-musllinux* cp38-macosx_arm64"
+skip = "cp*-musllinux*"
 test-command = "pytest {project}/tests"
 test-extras = ["test"]
 

--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ with open(os.path.join(this_directory, "README.md"), encoding="utf-8") as f:
 # logic and declaration, and simpler if you include description/version in a file.
 setup(
     name="sil-thot",
-    version="3.4.8",
+    version="3.4.9",
     author="SIL International",
     maintainer="Damien Daspit",
     maintainer_email="damien_daspit@sil.org",

--- a/src/stack_dec/_phraseHypothesisRec.h
+++ b/src/stack_dec/_phraseHypothesisRec.h
@@ -178,7 +178,7 @@ void _phraseHypothesisRec<SCORE_INFO, EQCLASS_FUNC, HYPSTATE>::getTrgTransForSrc
     std::pair<PositionIndex, PositionIndex> srcPhrPos, std::vector<WordIndex>& trgPhr) const
 {
   // Search source phrase in segmentation
-  unsigned int k;
+  unsigned int k = 0;
   bool srcPhrFound = false;
   for (unsigned int i = 0; i < data.sourceSegmentation.size(); ++i)
   {


### PR DESCRIPTION
This PR fixes an error that occurs when building the release binary on Ubuntu 24.04 using G++ 13.

It also adds the Python 3.13 and 3.14 wheels missing from 3.4.8 (see https://pypi.org/project/sil-thot/3.4.8/#files), and removes the invalid skips selectors for cibuildwheel flagged when building the wheels. Free-threaded wheels have been disabled as they are untested, and were causing the GHA to run for over an hour, resulting in termination.